### PR TITLE
New classes: Vocab for managing custom vocabularies

### DIFF
--- a/cf_pandas/__init__.py
+++ b/cf_pandas/__init__.py
@@ -8,6 +8,7 @@ from .accessor import CFAccessor  # noqa
 from .options import set_options  # noqa
 from .reg import Reg
 from .utils import always_iterable, astype, match_criteria_key
+from .vocab import Vocab
 
 
 try:

--- a/cf_pandas/vocab.py
+++ b/cf_pandas/vocab.py
@@ -1,0 +1,104 @@
+"""Class for creating and working with vocabularies."""
+
+import json
+import pathlib
+
+from collections import defaultdict
+from typing import DefaultDict, Dict, Optional, Union
+
+from .utils import astype
+
+
+class Vocab(object):
+    """Class to handle vocabularies."""
+
+    def __init__(self, openname: Optional[str] = None):
+        self.vocab: DefaultDict[str, Dict[str, str]]
+        if openname is not None:
+            self.vocab = defaultdict(dict, self.open_file(openname))
+        else:
+            self.vocab = defaultdict(dict)
+
+    def make_entry(
+        self, nickname: str, expressions: Union[str, list], attr: str = "standard_name"
+    ):
+        """Make an entry for vocab.
+
+        Parameters
+        ----------
+        nickname: str
+            The nickname to call the variable being represented in this entry.
+        expressions: str, list
+            Regular expression(s) to use to select out the variable in a regex match. Multiple expressions input in a list are piped together to create one str of expressions.
+        attr: str
+            What attribute to identify the regular expressions with. Default is "standard_name", but other reasonable options are any variable attributes in a netcdf file such as "units", "name", and "long_name".
+
+        Examples
+        --------
+
+        The following creates an entry in the vocabulary stored in `vocab.vocab`. It doesn't print the entry but it has been pasted in below the example to show what it looks like.
+
+        >>> import cf_pandas as cfp
+        >>> vocab = cfp.Vocab()
+        >>> vocab.make_entry("temp", ["a","b"], attr="name")
+        {'temp': {'standard_name': 'a|b'}})
+        """
+
+        expressions = astype(expressions, list)
+        entry: DefaultDict[str, Dict[str, str]] = defaultdict(dict)
+        entry[nickname][attr] = "|".join(expressions)
+        self.__add__(entry)
+
+    def __add__(self, other_vocab: Union[DefaultDict[str, Dict[str, str]], "Vocab"]):
+        """Add two Vocab objects together...
+
+        by adding their `.vocab`s together. Expressions are piped together but otherwise not changed.
+
+        Parameters
+        ----------
+        other_vocab: Vocab
+            Other Vocab object to combine with.
+        """
+
+        if isinstance(other_vocab, Vocab):
+            other_vocab = other_vocab.vocab
+
+        nicknames = set(list(self.vocab.keys()) + list(other_vocab.keys()))
+        for nickname in nicknames:
+
+            # gather all attributes under nickname as a set to compare their expressions
+            attributes = set(
+                list(self.vocab[nickname].keys()) + list(other_vocab[nickname].keys())
+            )
+
+            # pipe together expressions for nickname-attribute pairs
+            for attribute in attributes:
+                new_expressions = (
+                    self.vocab[nickname].get(attribute, "")
+                    + "|"
+                    + other_vocab[nickname].get(attribute, "")
+                ).strip("|")
+                self.vocab[nickname][attribute] = new_expressions
+        return self
+
+    def save(self, savename: Union[str, pathlib.PurePath]):
+        """Save to file.
+
+        Parameters
+        ----------
+        savename: str, PurePath
+            Filename to save to.
+        """
+        a_file = open(astype(savename, pathlib.PurePath).with_suffix(".json"), "w")
+        json.dump(self.vocab, a_file)
+        a_file.close()
+
+    def open_file(self, openname: Union[str, pathlib.PurePath]):
+        """Open previously-saved vocab.
+
+        Parameters
+        ----------
+        openname: str
+            Where to find vocab to open.
+        """
+        return json.loads(open(openname, "r").read())

--- a/cf_pandas/vocab.py
+++ b/cf_pandas/vocab.py
@@ -19,6 +19,10 @@ class Vocab(object):
         else:
             self.vocab = defaultdict(dict)
 
+    def __repr__(self):
+        """Representation."""
+        return dict(self.vocab).__repr__()
+
     def make_entry(
         self, nickname: str, expressions: Union[str, list], attr: str = "standard_name"
     ):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,15 @@ Accessor
    :undoc-members:
    :show-inheritance:
 
+``cf-pandas`` utilities
+***********************
+
+.. automodule:: cf_pandas.utils
+   :members:
+   :inherited-members:
+   :undoc-members:
+   :show-inheritance:
+
 Reg class for writing regular expressions
 *****************************************
 
@@ -25,10 +34,10 @@ Reg class for writing regular expressions
    :undoc-members:
    :show-inheritance:
 
-``cf-pandas`` utilities
-***********************
+Vocab class for handling custom variable-selection vocabularies
+***************************************************************
 
-.. automodule:: cf_pandas.utils
+.. automodule:: cf_pandas.vocab
    :members:
    :inherited-members:
    :undoc-members:

--- a/docs/demo_vocab.md
+++ b/docs/demo_vocab.md
@@ -46,7 +46,7 @@ criteria
 
 You can set your vocabulary to be used generally, or use with a context-manager. I recommend using the context-manager approach whenever you might use more than one vocabulary.
 
-To set it generally for, for example, `cf-xarray`, you would do: 
+To set it generally for, for example, `cf-xarray`, you would do:
 
 ```cf_xarray.set_options(custom_criteria=criteria)```
 

--- a/docs/demo_vocab.md
+++ b/docs/demo_vocab.md
@@ -1,0 +1,140 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.0
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# `Vocab`: manage custom vocabularies
+
+Custom vocabularies are used in `cf-xarray` and `cf-pandas` to search variable names and available metadata (in the case of `cf-xarray` with Dataset variable attributes) and compare with regular expressions to make selections. These make it possible to generically select variables from different Datasets and DataFrames. However, they are difficult to write, handle, and maintain, and control which variables are found so being able to tweak them is important.
+
+```{code-cell} ipython3
+import cf_pandas as cfp
+import regex
+```
+
+## What does a custom vocabulary look like?
+
+### `cf-xarray`
+For a netcdf-style Dataset, this criteria dictionary will be used to search over the attributes in each variable and compare with the regular expressions to search for matches, in this case checking specifically the variable `standard_name` and `name`. There will be a match to the nickname "ssh" if the `standard_name` for a variable is exactly "sea_surface_height" or if the `standard_name` contains the string "sea_surface_elevation".
+
+### `cf-pandas`
+`cf-pandas` is made to access `pandas` DataFrames in an analogous manner to using the `cf-xarray` accessor with Datasets. DataFrames do not have attributes to compare with, only the column name. So, every regular expression for a given nickname (in the example given, "ssh" and "temp"), will be compared with the column name. The extra dictionary structure is maintained in this case so that vocabularies can be used between `cf-xarray` and `cf-pandas` if needed, for example, to select a model variable and compare it with a data file variable.
+
+```{code-cell} ipython3
+criteria = {
+    "ssh": {
+        "standard_name": "sea_surface_height$|sea_surface_elevation",
+        "name": "(?i)sea_surface_elevation(?!.*?_qc)"
+    },
+    "temp": {
+        "standard_name": "sea_water_temperature",
+        "name": "(?i)temperature(?!.*(skin|ground|air|_qc))"
+    },
+}
+criteria
+```
+
+## How should I use the custom vocabulary?
+
+You can set your vocabulary to be used generally, or use with a context-manager. I recommend using the context-manager approach whenever you might use more than one vocabulary.
+
+To set it generally for, for example, `cf-xarray`, you would do: 
+
+```cf_xarray.set_options(custom_criteria=criteria)```
+
+or for `cf-pandas`, imported as `cfp`:
+
+```cfp.set_options(custom_criteria=criteria)```
+
+In this demo, we will use the context manager approach so that we can use more than one vocabulary. For example, here we compare a list of strings with the vocabulary we called `criteria` and are searching for all matches in the list to the variable by the nickname "ssh".
+
+```{code-cell} ipython3
+vals = ["zeta", "sea_surface_height", "sea_surface", "sea_surface_elevation_zeta"]
+
+with cfp.set_options(custom_criteria=criteria):
+    print(cfp.match_criteria_key(vals, "ssh"))
+```
+
+## How can I make a custom vocabulary? Introducing the Vocab class.
+
+As you can see, making `criteria` could be labor intensive. Also, users may want to create more than one of these and use them separately or together in different circumstances, and save them for later. That is what the `Vocab` class in `cf-pandas` is meant to help with.
+
+In this example, we make an entry in our vocabulary that has two regular expressions in it to start.
+
+```{code-cell} ipython3
+# initialize class
+vocab1 = cfp.Vocab()
+
+# Make an entry to add to your vocabulary
+vocab1.make_entry("new_variable_nickname", ["match_this_exactly$", "match_that_exactly$"], attr="name")
+```
+
+Retrieve the vocabulary you've made with `vocab1.vocab`:
+
+```{code-cell} ipython3
+vocab1.vocab
+```
+
+And you can subsequently add other entries:
+
+```{code-cell} ipython3
+# add another entry
+vocab1.make_entry("new_variable_nickname", ["match_this_string", "match_that_exactly$"], attr="long_name")
+
+# add another entry
+vocab1.make_entry("other_variable_nickname", "match_that_string", attr="standard_name")
+```
+
+```{code-cell} ipython3
+vocab1
+```
+
+Test our new vocabulary:
+
+```{code-cell} ipython3
+vals = ["match_this_exactly", "match_this_exactly_but", "other_variable_nickname", "match_that_string"]
+
+with cfp.set_options(custom_criteria=vocab1.vocab):
+    print(cfp.match_criteria_key(vals, "new_variable_nickname"))
+```
+
+## Working with vocabularies
+
++++
+
+### Save to file
+
+Save your new vocabulary to a file with:
+
+`vocab1.save(filename)`
+
++++
+
+### Read from file
+
+Retrieve your previously-saved vocabulary by inputting the path into a new instantiation of the Vocab class with:
+
+`vocab_read = cfp.Vocab(filepath)`
+
++++
+
+### Combine
+
+```{code-cell} ipython3
+vocab1 = cfp.Vocab()
+vocab1.make_entry("new_variable_nickname", ["match_this_exactly$", "match_that_exactly$"], attr="name")
+
+vocab2 = cfp.Vocab()
+vocab2.make_entry("new_variable_nickname", ["match_this_string", "match_that_exactly$"], attr="long_name")
+vocab2.make_entry("other_variable_nickname", "match_that_string", attr="standard_name")
+
+vocab1 + vocab2
+```

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,0 +1,84 @@
+"""Test vocab"""
+
+import os
+
+from collections import defaultdict
+
+import cf_pandas as cfp
+
+
+def test_init():
+    vocab = cfp.Vocab()
+    assert isinstance(vocab.vocab, defaultdict)
+
+
+def test_make_entry():
+    vocab = cfp.Vocab()
+    vocab.make_entry("temp", ["a", "b"], attr="name")
+    assert vocab.vocab == {"temp": {"name": "a|b"}}
+
+
+def test_add_vocabs():
+    vocab = cfp.Vocab()
+    vocab.make_entry("temp", ["a", "b"], attr="standard_name")
+    vocab.make_entry("salt", ["a", "b"], attr="name")
+    compare = {"temp": {"standard_name": "a|b|a|b"}, "salt": {"name": "a|b|a|b"}}
+    assert (vocab + vocab).vocab == compare
+
+    vocab2 = cfp.Vocab()
+    vocab2.make_entry("temp", ["a", "b"], attr="name")
+    compare = {
+        "temp": {"name": "a|b", "standard_name": "a|b|a|b"},
+        "salt": {"name": "a|b|a|b"},
+    }
+    assert (vocab + vocab2).vocab == compare
+
+
+def test_make_more_entries():
+    vocab = cfp.Vocab()
+    vocab.make_entry("temp", ["a", "b"], attr="name")
+    vocab.make_entry("temp", ["a", "b"], attr="standard_name")
+    vocab.make_entry("salt", ["a", "b"], attr="name")
+    vocab.make_entry("salt", ["a", "b"], attr="name")
+    compare = {
+        "temp": {"name": "a|b", "standard_name": "a|b"},
+        "salt": {"name": "a|b|a|b"},
+    }
+    assert vocab.vocab == compare
+
+
+def test_make_entry_with_Reg():
+    reg1 = cfp.Reg(
+        exclude=["abc", "123"],
+        exclude_end=["def", "45"],
+        exclude_start=["ghi", "67"],
+        include=["jkl", "mno"],
+        include_end="z",
+        include_start="the",
+    )
+    vocab = cfp.Vocab()
+    vocab.make_entry("words", reg1.pattern(), attr="name")
+    assert vocab.vocab == {"words": {"name": reg1.pattern()}}
+    reg2 = cfp.Reg(
+        exclude=["abc", "45"],
+        exclude_end=["def", "67"],
+        exclude_start=["ghi", "123"],
+        include=["jkl", "pr"],
+        include_end="z",
+        include_start="the",
+    )
+    vocab.make_entry("words", reg2.pattern(), attr="name")
+    assert vocab.vocab == {"words": {"name": f"{reg1.pattern()}|{reg2.pattern()}"}}
+
+
+def test_save_and_open(tmpdir):
+    # save
+    vocab = cfp.Vocab()
+    vocab.make_entry("temp", ["a", "b"], attr="name")
+    fname = f"{tmpdir}/testsave.json"
+    vocab.save(fname)
+    assert os.path.exists(fname) == 1
+
+    # open
+    vocab2 = cfp.Vocab(fname)
+    assert vocab.vocab == vocab2.vocab


### PR DESCRIPTION
This PR is for Vocab only, though uses Reg for a couple of tests and doc examples.

The three are:

Reg, class for writing regular expressions
Vocab, class for writing and working with vocabularies/custom criteria/ontologies that will work with cf-xarray and cf-pandas
widget class that helps a person sort through a lot of options to choose what should count as exact matches in a vocabulary, such as for a server they will use