### PR TITLE
Split

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     - id: file-contents-sorter
       files: requirements-dev.txt
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.7.9
   hooks:
     - id: flake8

--- a/cf_pandas/accessor.py
+++ b/cf_pandas/accessor.py
@@ -6,6 +6,12 @@ import pandas as pd
 
 import cf_pandas as cfp
 
+try:
+    #delete the accessor to avoid warning 
+    del pd.DataFrame.cf
+except AttributeError:
+    pass
+
 
 @pd.api.extensions.register_dataframe_accessor("cf")
 class CFAccessor:

--- a/cf_pandas/accessor.py
+++ b/cf_pandas/accessor.py
@@ -6,8 +6,9 @@ import pandas as pd
 
 import cf_pandas as cfp
 
+
 try:
-    #delete the accessor to avoid warning 
+    # delete the accessor to avoid warning
     del pd.DataFrame.cf
 except AttributeError:
     pass

--- a/cf_pandas/utils.py
+++ b/cf_pandas/utils.py
@@ -61,6 +61,7 @@ def match_criteria_key(
     available_values: list,
     keys_to_match: Union[str, list],
     criteria: Optional[dict] = None,
+    split: bool = False,
 ) -> list:
     """Use criteria to choose match to key from available available_values.
 
@@ -72,6 +73,8 @@ def match_criteria_key(
         Key(s) from criteria to match with available_values.
     criteria : dict, optional
         Criteria to use to map from variable to attributes describing the variable. If user has defined custom_criteria, this will be used by default.
+    split : bool, optional
+        If split is True, split the available_values by white space before performing matches. This is helpful e.g. when columns headers have the form "standard_name (units)" and you want to match standard_name.
 
     Returns
     -------
@@ -93,17 +96,32 @@ def match_criteria_key(
             # criterion is the attribute type — in this function we don't use it,
             # instead we use all the patterns available in criteria to match with available_values
             for criterion, patterns in custom_criteria[key].items():
-                results.extend(
-                    list(
-                        set(
-                            [
-                                value
-                                for value in available_values
-                                if regex.match(patterns, value)
-                            ]
+                if split:
+                    results.extend(
+                        list(
+                            set(
+                                [
+                                    value
+                                    for value in available_values
+                                    for value_part in value.split()
+                                    if regex.match(patterns, value_part)
+                                ]
+                            )
                         )
                     )
-                )
+
+                else:
+                    results.extend(
+                        list(
+                            set(
+                                [
+                                    value
+                                    for value in available_values
+                                    if regex.match(patterns, value)
+                                ]
+                            )
+                        )
+                    )
 
         # catch scenario that user input valid reader variable names
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,6 +22,22 @@ def test_match_criteria_key():
     assert cfp.match_criteria_key(vals, ["wind_s"], criteria) == ["wind_speed"]
 
 
+def test_match_criteria_key_split():
+
+    vals = ["wind_speed (m/s)", "WIND_SPEED", "wind_speed_status"]
+
+    # test function with set_options criteria
+    with cfp.set_options(custom_criteria=criteria):
+        assert cfp.match_criteria_key(vals, ["wind_s"], split=True) == [
+            "wind_speed (m/s)"
+        ]
+
+    # test function with input criteria
+    assert cfp.match_criteria_key(vals, ["wind_s"], criteria, split=True) == [
+        "wind_speed (m/s)"
+    ]
+
+
 def test_standard_names():
 
     names = cfp.standard_names()


### PR DESCRIPTION
Responses from ERDDAP tabledap are csvp which are "standard_name (units)" which breaks my vocab matching. This adds an optional split in the cf-pandas code for matching that will consider split matches. (splitting over white space)