### PR TITLE
get axes/coords use regex matching too

### DIFF
--- a/cf_pandas/utils.py
+++ b/cf_pandas/utils.py
@@ -5,8 +5,10 @@ Utilities for cf-pandas.
 from collections import ChainMap
 from typing import Any, Iterable, Optional, Union
 
+import numpy as np
 import pandas as pd
 import regex
+from pandas import Series
 
 from .options import OPTIONS
 
@@ -152,3 +154,12 @@ def standard_names():
     standard_names = [entry.get("id") for entry in soup.find_all("entry")]
 
     return standard_names
+
+
+def _is_datetime_like(da: Series) -> bool:
+    if np.issubdtype(da.dtype, np.datetime64) or np.issubdtype(
+        da.dtype, np.timedelta64
+    ):
+        return True
+
+    return False

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -121,3 +121,10 @@ def test_set_item():
         assert all(df.cf["temp"].values == np.arange(8))
         df.cf["longitude"] = np.arange(8)
         assert all(df.cf["longitude"].values == np.arange(8))
+
+
+def test_get_by_guess_regex():
+    df = pd.DataFrame(columns=["lon", "lat", "min"])
+    assert df.cf["longitude"].name == "lon"
+    assert df.cf["latitude"].name == "lat"
+    assert df.cf["time"].name == "min"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from unittest import mock
 
+import pandas as pd
 import requests
 
 import cf_pandas as cfp
@@ -49,3 +50,14 @@ def test_standard_names(mock_requests):
     mock_requests.return_value = resp
     names = cfp.standard_names()
     assert "wind_speed" in names
+
+
+def test__is_datetime_like():
+    df = pd.DataFrame()
+    df["time"] = pd.date_range(start="2001-1-1", end="2001-1-5", freq="1D")
+    assert cfp.utils._is_datetime_like(df["time"])
+
+    df = pd.DataFrame()
+    df["time"] = ["2001-1-1", "2001-1-2", "2001-1-3"]
+    assert not cfp.utils._is_datetime_like(df["time"])
+    assert cfp.utils._is_datetime_like(pd.to_datetime(df["time"]))


### PR DESCRIPTION
Built into _get_axis_coord now is logic from cf-xarray guess_axis_coord for regex matching. This is done here if no other results have been found to help find reasonable matches.
