### PR TITLE
guess_regex was not used correctly

### DIFF
--- a/cf_pandas/accessor.py
+++ b/cf_pandas/accessor.py
@@ -354,7 +354,7 @@ def _get_axis_coord(obj: Union[DataFrame, Series], key: str) -> list:
         # also use the guess_regex approach by default, but only if no results so far
         # this takes the logic from cf-xarray guess_coord_axis
         if len(results) == 0:
-            if obj[col].ndim == 1 and _is_datetime_like(obj[col]):
+            if key in ("T", "time") and _is_datetime_like(obj[col]):
                 results.update((col,))
                 continue  # prevent second detection
 


### PR DESCRIPTION
If guess_regex was used in _get_axis_coord, all keys would use the identified time column because it was not being limited to just T and time. Now it is.