### PR TITLE
Accessor can return indices, some guess_regex terms can be in middle of string now.

### DIFF
--- a/cf_pandas/accessor.py
+++ b/cf_pandas/accessor.py
@@ -114,7 +114,7 @@ class CFAccessor:
         # return series for column
         if len(col_names) == 1 and col_names[0] in self._obj.columns:
             return self._obj[col_names[0]]
-        # return index 
+        # return index
         elif len(col_names) == 1 and col_names[0] in self._obj.index.names:
             return self._obj.index.get_level_values(col_names[0])
         # return DataFrame
@@ -251,7 +251,7 @@ class CFAccessor:
         }
 
         return vardict
-    
+
     @property
     def axes_cols(self) -> List[str]:
         """
@@ -262,9 +262,9 @@ class CFAccessor:
         list
             Variable names that are the column names which represent axes.
         """
-        
+
         return list(itertools.chain(*[*self.axes.values()]))
-    
+
     @property
     def coordinates_cols(self) -> List[str]:
         """
@@ -275,7 +275,7 @@ class CFAccessor:
         list
             Variable names that are the column names which represent coordinates.
         """
-        
+
         return list(itertools.chain(*[*self.coordinates.values()]))
 
     @property

--- a/cf_pandas/accessor.py
+++ b/cf_pandas/accessor.py
@@ -62,14 +62,14 @@ class CFAccessor:
         # self._validate(pandas_obj)
         self._obj = pandas_obj
 
-    @staticmethod
-    def _validate(obj):
+    # @staticmethod
+    def _validate(self):
         """what is necessary for basic use."""
 
         # verify that necessary keys are present. Z would also be nice but might be missing.
         # but don't use the accessor to check
         keys = ["T", "longitude", "latitude"]
-        missing_keys = [key for key in keys if len(_get_axis_coord(obj, key)) == 0]
+        missing_keys = [key for key in keys if len(_get_axis_coord(self._obj, key)) == 0]
         if len(missing_keys) > 0:
             raise AttributeError(
                 f'{"longitude", "latitude", "time"} must be identifiable in DataFrame but {missing_keys} are missing.'

--- a/cf_pandas/criteria.py
+++ b/cf_pandas/criteria.py
@@ -103,15 +103,24 @@ for coord, attrs in coordinate_criteria.items():
 coordinate_criteria["X"]["long_name"] += ("cell index along first dimension",)
 coordinate_criteria["Y"]["long_name"] += ("cell index along second dimension",)
 
+# changes allow for the pattern string to not be at the start of the comparison string
+# like (?=.*lon)
 guess_regex = {
-    "time": re.compile("\\bt\\b|(time|min|hour|day|week|month|year)[0-9]*"),
+    "time": re.compile("\\bt\\b|(?=.*time|min|hour|day|week|month|year)[0-9]*"),
+    # "time": re.compile("\\bt\\b|(time|min|hour|day|week|month|year)[0-9]*"),
     "Z": re.compile(
-        "(z|nav_lev|gdep|lv_|[o]*lev|bottom_top|sigma|h(ei)?ght|altitude|depth|"
+        "(z|nav_lev|gdep|lv_|[o]*lev|bottom_top|sigma|(?=.*dbars)|h(ei)?ght|altitude|depth|"
         "isobaric|pres|isotherm)[a-z_]*[0-9]*"
     ),
+    # "Z": re.compile(
+    #     "(z|nav_lev|gdep|lv_|[o]*lev|bottom_top|sigma|h(ei)?ght|altitude|depth|"
+    #     "isobaric|pres|isotherm)[a-z_]*[0-9]*"
+    # ),
     "Y": re.compile("y|j|nlat|nj"),
-    "latitude": re.compile("y?(nav_lat|lat|gphi)[a-z0-9]*"),
+    "latitude": re.compile("y?(nav_lat|(?=.*lat)|gphi)[a-z0-9]*"),
+    # "latitude": re.compile("(?i)y?(?=.*lat)[a-z0-9]*"),
     "X": re.compile("x|i|nlon|ni"),
-    "longitude": re.compile("x?(nav_lon|lon|glam)[a-z0-9]*"),
+    # "longitude": re.compile("(?i)x?(?=.*lon)[a-z0-9]*"),
+    "longitude": re.compile("x?(nav_lon|(?=.*lon)|glam)[a-z0-9]*"),
 }
 guess_regex["T"] = guess_regex["time"]

--- a/cf_pandas/criteria.py
+++ b/cf_pandas/criteria.py
@@ -118,9 +118,7 @@ guess_regex = {
     # ),
     "Y": re.compile("y|j|nlat|nj"),
     "latitude": re.compile("y?(nav_lat|(?=.*lat)|gphi)[a-z0-9]*"),
-    # "latitude": re.compile("(?i)y?(?=.*lat)[a-z0-9]*"),
     "X": re.compile("x|i|nlon|ni"),
-    # "longitude": re.compile("(?i)x?(?=.*lon)[a-z0-9]*"),
     "longitude": re.compile("x?(nav_lon|(?=.*lon)|glam)[a-z0-9]*"),
 }
 guess_regex["T"] = guess_regex["time"]

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -33,7 +33,7 @@ def test_validate():
         ]
     )
     with pytest.raises(AttributeError):
-        df.cf.keys()
+        df.cf._validate()
 
 
 def test_match_criteria_key_accessor():

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -139,3 +139,9 @@ def test_index():
     df = pd.DataFrame(index=["m_time"])
     df.index.rename("m_time", inplace=True)
     assert df.cf["T"].name == "m_time"
+
+
+def test_cols():
+    df = pd.DataFrame(columns=["m_time", "lon", "lat", "temp"])
+    assert df.cf.axes_cols == ["m_time"]
+    assert sorted(df.cf.coordinates_cols) == ["lat", "lon", "m_time"]

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -128,3 +128,14 @@ def test_get_by_guess_regex():
     assert df.cf["longitude"].name == "lon"
     assert df.cf["latitude"].name == "lat"
     assert df.cf["time"].name == "min"
+
+    df = pd.DataFrame(columns=["blah_lon", "table_lat"])
+    assert df.cf["longitude"].name == "blah_lon"
+    assert df.cf["latitude"].name == "table_lat"
+
+
+def test_index():
+    """Test when time is in index."""
+    df = pd.DataFrame(index=["m_time"])
+    df.index.rename("m_time", inplace=True)
+    assert df.cf["T"].name == "m_time"


### PR DESCRIPTION
accessor changes:
* indexes in a DataFrame can now be returned when a cf key/axis/coordinate is requested, in addition to columns
* for axis and coordinates as well as for custom names/vocabs
* Some improvements in the handling of guessing when matches are not found
* don't automatically validate now which requires the presence of T, longitude, and latitude. However, it is still available to be used if desired. It was too limiting for the cases when you want to use functionality from cf-pandas without the use case fitting exactly.
* new properties:
  *  `axes_cols` which returns Variable names that are the column names which represent axes.
  *  `coordinates_cols` which returns Variable names that are the column names which represent coordinates.

updates to guess_regex:
* for Z, "dbars" no longer has to be at the start of the string to match
* for time, "time" no longer has to be at the start of the string to match
* for latitude and longitude, "lat" and "lon", respectively, no longer have to be at the start of the string to match.
This should probably be a change for all such matches, but I want to discuss with cf-xarray people.

Added some more tests too